### PR TITLE
Create unique hash for filenames to get safe file names

### DIFF
--- a/epubgen/epub.go
+++ b/epubgen/epub.go
@@ -48,6 +48,7 @@ func (e *epubmaker) changeRefs(i int, img *goquery.Selection) {
 func (e *epubmaker) downloadImages(i int, img *goquery.Selection) {
 	util.CyanBold.Println("Downloading Images")
 	imgSrc, exists := img.Attr("src")
+
 	if exists {
 
 		//don't download same thing twice
@@ -55,7 +56,11 @@ func (e *epubmaker) downloadImages(i int, img *goquery.Selection) {
 			return
 		}
 
-		imgRef, err := e.Epub.AddImage(imgSrc, "")
+		//pass unique and safe image names here, then it will not crash on windows
+		//use murmur hash to generate file name
+		imageFileName:=util.GetHash(imgSrc)
+
+		imgRef, err := e.Epub.AddImage(imgSrc, imageFileName)
 		if err != nil {
 			util.Red.Printf("Couldn't add image %s : %s\n", imgSrc, err)
 			return

--- a/util/murmurhash.go
+++ b/util/murmurhash.go
@@ -1,0 +1,67 @@
+package util
+
+import "strconv"
+
+func GetHash(name string) string{
+	hash:=murmurHash64B([]byte(name), 0)
+	hashStr:=strconv.Itoa(int(hash))
+	return hashStr
+}
+func murmurHash64B(key []byte, seed uint64) (hash uint64) {
+	const m uint32 = 0x5bd1e995
+	const r = 24
+
+	var l int = len(key)
+	var h1 uint32 = uint32(seed) ^ uint32(l)
+	var h2 uint32 = uint32(seed) >> 32
+
+	var data []byte = key
+
+	var k1, k2 uint32
+
+	for l >= 8 {
+		k1 = uint32(data[0]) + uint32(data[1]) << 8 + uint32(data[2]) << 16 + uint32(data[3]) << 24
+		k1 *= m; k1 ^= k1 >> r; k1 *=m
+		h1 *= m; h1 ^= k1
+		data = data[4:]
+		l -= 4
+
+		k2 = uint32(data[0]) + uint32(data[1]) << 8 + uint32(data[2]) << 16 + uint32(data[3]) << 24
+		k2 *= m; k2 ^= k2 >> r; k2 *= m
+		h2 *= m; h2 ^= k2
+		data = data[4:]
+		l -= 4
+	}
+
+	if l >= 4 {
+		k1 = uint32(data[0]) + uint32(data[1]) << 8 + uint32(data[2]) << 16 + uint32(data[3]) << 24
+		k1 *= m; k1 ^= k1 >> r; k1 *= m
+		h1 *= m; h1 ^= k1
+		data = data[4:]
+		l -= 4
+	}
+
+	switch l {
+	case 3:
+		h2 ^= uint32(data[2]) << 16
+		fallthrough
+	case 2:
+		h2 ^= uint32(data[1]) << 8
+		fallthrough
+	case 1:
+		h2 ^= uint32(data[0])
+		h2 *= m
+	}
+
+	h1 ^= h2 >> 18; h1 *= m
+	h2 ^= h1 >> 22; h2 *= m
+	h1 ^= h2 >> 17; h1 *= m
+	h2 ^= h1 >> 19; h2 *= m
+
+	var h uint64 = uint64(h1)
+
+	h = (h << 32) | uint64(h2)
+
+	return h
+
+}


### PR DESCRIPTION
This will fix #9 

Local image names will be the murmurhash for the img src, so that filename doesn't crash on windows.

Changes will be in release v1.0.2