### PR TITLE
Fix image rendering

### DIFF
--- a/mail/mailer.go
+++ b/mail/mailer.go
@@ -1,7 +1,6 @@
 package mail
 
 import (
-	"fmt"
 	"github.com/nikhil1raghav/kindle-send/util"
 	"os"
 	"time"
@@ -19,32 +18,36 @@ func Send(files []string, timeout int) {
 
 	msg.SetBody("text/plain", "")
 
-	tosend := 0
+	attachedFiles:=make([]string,0)
 	for _, file := range files {
 		_, err := os.Stat(file)
 		if err != nil {
 			util.Red.Printf("Couldn't find the file %s : %s \n", file, err)
 			continue
 		} else {
-			tosend++
 			msg.Attach(file)
+			attachedFiles=append(attachedFiles,file)
 		}
 	}
-	if tosend == 0 {
+	if len(attachedFiles) == 0 {
 		util.Cyan.Println("No files to send")
 		return
 	}
 
 	dialer := gomail.NewDialer(cfg.Server, cfg.Port, cfg.Sender, cfg.Password)
 	dialer.Timeout=time.Duration(timeout)*time.Second
-	fmt.Println("Dialer timeout ", dialer.Timeout)
-
 	util.CyanBold.Println("Sending mail")
+	util.Cyan.Println("Mail timeout : ", dialer.Timeout.String())
+	util.Cyan.Println("Following files will be sent :")
+	for i,file:=range attachedFiles{
+		util.Cyan.Printf("%d. %s\n",i+1,file)
+	}
+
 	if err := dialer.DialAndSend(msg); err != nil {
 		util.Red.Println("Error sending mail : ", err)
 		return
 	} else {
-		util.GreenBold.Printf("Mailed %d files to %s", tosend, cfg.Receiver)
+		util.GreenBold.Printf("Mailed %d files to %s", len(attachedFiles), cfg.Receiver)
 	}
 
 }

--- a/main.go
+++ b/main.go
@@ -48,17 +48,24 @@ func main() {
 	filePath := flag.String("file", "", "Mail a file to kindle, use kindle-send as a simple mailer")
 	mailTimeout :=flag.Int("mail-timeout",120, "Timeout for sending mail in Seconds" )
 	_ =flag.Bool("version", false, "Print version information")
+	_ =flag.Bool("dry-run", false, "Save epub locally and don't send to device")
 
 	flag.Parse()
 	passed := 0
 	flag.Visit(func(f *flag.Flag) {
 		passed++
 	})
-	if passed == 0 {
-		flag.PrintDefaults()
-	}
+
 	if flagPassed("version"){
 		util.PrintVersion()
+		if passed==1{
+			return
+		}
+	}
+
+
+	if passed == 0 {
+		flag.PrintDefaults()
 	}
 
 
@@ -87,6 +94,15 @@ func main() {
 		} else {
 			filesToSend = append(filesToSend, book)
 		}
+	}
+
+	if flagPassed("dry-run"){
+		util.CyanBold.Println("Dry-run mode : Not sending files to device")
+		util.Cyan.Println("Following files are saved")
+		for i,file:=range filesToSend{
+			util.Cyan.Printf("%d %s\n",i+1,file)
+		}
+		return
 	}
 	if len(filesToSend) != 0 {
 		timeout:=config.DefaultTimeout

--- a/util/murmurhash.go
+++ b/util/murmurhash.go
@@ -1,11 +1,16 @@
 package util
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+)
 
 func GetHash(name string) string{
 	hash:=murmurHash64B([]byte(name), 0)
 	hashStr:=strconv.Itoa(int(hash))
-	return hashStr
+
+	//TODO: this works but is functionally incorrect, assign mimetype based on content
+	return fmt.Sprintf("img%s.png",hashStr)
 }
 func murmurHash64B(key []byte, seed uint64) (hash uint64) {
 	const m uint32 = 0x5bd1e995


### PR DESCRIPTION
Will fix image rendering bug introduced in #10 by not assigning an extension to hashed name of the image.
Added `dry-run` flag to save epubs locally and not send #15 
List files before sending or saving 